### PR TITLE
Fix pinned element jump out of container in Chrome

### DIFF
--- a/jquery.pin.js
+++ b/jquery.pin.js
@@ -36,8 +36,8 @@
                 $this.data("pin", {
                     pad: pad,
                     from: (options.containerSelector ? containerOffset.top : offset.top) - pad.top,
-                    to: containerOffset.top + $container.height() - $this.outerHeight() - pad.bottom,
-                    end: containerOffset.top + $container.height(),
+                    to: (containerOffset.top + $container.height() - $this.outerHeight() - pad.bottom),
+                    end: (containerOffset.top + $container.height()),
                     parentTop: parentOffset.top
                 });
 


### PR DESCRIPTION
Adding parenthesis around to/end calculations because Chrome was concatenating instead of doing math. (Change not added to minified file.)
